### PR TITLE
Namespaced Ability

### DIFF
--- a/app/helpers/mokio/backend/backend_helper.rb
+++ b/app/helpers/mokio/backend/backend_helper.rb
@@ -98,6 +98,19 @@ module Mokio
         html.html_safe
       end
 
+      #
+      # Can user manage any site elements
+      #
+      def can_manage_site_elements?
+        (
+          (can? :manage, Mokio::StaticModule) ||
+          (can? :create, Mokio::StaticModule) ||
+          (can? :manage, Mokio::ModulePosition) ||
+          (can? :create, Mokio::ModulePosition) ||
+          (can? :manage, Mokio::ExternalScript) ||
+          (can? :create, Mokio::ExternalScript)
+        )
+      end
     end
   end
 end

--- a/app/models/mokio/ability.rb
+++ b/app/models/mokio/ability.rb
@@ -1,7 +1,7 @@
-class Ability
-  include CanCan::Ability
+module Mokio
+  class Ability
+    include CanCan::Ability
 
-  def initialize(user)
     # Define abilities for the passed in user here. For example:
     #
     #   user ||= User.new # guest user (not logged in)
@@ -28,31 +28,28 @@ class Ability
     #
     # See the wiki for details:
     # https://github.com/bryanrite/cancancan/wiki/Defining-Abilities
+    def initialize(user)
+      if user.has_role? :admin
+        can :manage, :all
+      end
+      if user.has_role? :content_editor
+        can :manage, [Mokio::Content]
+      end
+      if user.has_role? :menu_editor
+        can :manage, [Mokio::Menu]  
+      end
+      if user.has_role? :static_module_editor
+        can :manage, [Mokio::StaticModule]  
+      end
+      if user.has_role? :user_editor
+        can :manage, [Mokio::User]
+      end
+      if user.has_role? :reader
+        can :read, :all
+      end
 
-    if user.has_role? :admin
-      can :manage, :all
+      can :edit_password, Mokio::User
+      can :update_password, Mokio::User
     end
-    if user.has_role? :content_editor
-      can :manage, [Mokio::Content]
-    end
-    if user.has_role? :menu_editor
-      can :manage, [Mokio::Menu]  
-    end
-    if user.has_role? :static_module_editor
-      can :manage, [Mokio::StaticModule]  
-    end
-    if user.has_role? :user_editor
-      can :manage, [Mokio::User]
-    end
-    if user.has_role? :reader
-      can :read, :all
-    end
-
-    can :edit_password, Mokio::User
-    can :update_password, Mokio::User
-
-
-
   end
 end
-

--- a/app/views/mokio/layout/sidebar.html.slim
+++ b/app/views/mokio/layout/sidebar.html.slim
@@ -26,7 +26,7 @@
               = sidebar_btn Mokio::MovGallery, "icomoon-icon-movie"
               = sidebar_btn Mokio::Contact, "icomoon-icon-mail-3"
         /  SITE ELEMENTS
-        - if can? :create, Mokio::Content
+        - if can_manage_site_elements?
           li.site_elements_nav
             a href="#"
               span.icon16.icomoon-icon-puzzle

--- a/lib/mokio/concerns/controllers/base.rb
+++ b/lib/mokio/concerns/controllers/base.rb
@@ -57,9 +57,9 @@ module Mokio
         #
         # override current_ability to use Mokio's one
         #
-        # def current_ability
-        #   @current_ability ||= Mokio::Ability.new(current_user)
-        # end
+        def current_ability
+          @current_ability ||= Mokio::Ability.new(current_user)
+        end
       end
     end
   end

--- a/lib/mokio/concerns/controllers/base.rb
+++ b/lib/mokio/concerns/controllers/base.rb
@@ -53,6 +53,13 @@ module Mokio
           @breadcrumbs_prefix = ""
           @breadcrumbs_prefix_link = ""
         end
+
+        #
+        # override current_ability to use Mokio's one
+        #
+        # def current_ability
+        #   @current_ability ||= Mokio::Ability.new(current_user)
+        # end
       end
     end
   end


### PR DESCRIPTION
There was inconsistency in Mokio's user and his ability. Mokio::User was namespaced, and his Ability was not. Also added little fix for site elements premissions in sidebar view.