### PR TITLE
Updated/Fixed: Slug Uniqueness validator/ Fake menus generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -388,3 +388,12 @@
 ### Mokio 10.12.2019 v2.0.3
 <br/>
   1. Update datatable API
+
+### Mokio 11.12.2019 v2.0.4
+<br />
+  1. 'Uniqueness validator will no longer enforce case sensitive comparison'
+    Added: `case_sensitive: true` to :slug in
+    - Mokio::Menu
+    - Mokio::DataFile
+  2. Updated: fake menu generation
+  3. Fixed: Mokio::Menu belongs_to Mokio::Meta // optional: true

--- a/lib/mokio/concerns/models/data_file.rb
+++ b/lib/mokio/concerns/models/data_file.rb
@@ -11,7 +11,7 @@ module Mokio
           extend FriendlyId
 
           friendly_id :slug_candidates, use: :slugged
-          validates_uniqueness_of :slug
+          validates_uniqueness_of :slug,case_sensitive: true
           belongs_to :contents, :touch => true
 
           mount_uploader :data_file, Mokio::DataFileUploader

--- a/lib/mokio/concerns/models/lang.rb
+++ b/lib/mokio/concerns/models/lang.rb
@@ -84,19 +84,18 @@ module Mokio
         if(@menu.save)
           self.menu_id = @menu.id
           self.save(:validate => false)
-          result = Mokio::Menu.all.fake_structure_unique
+          result = Mokio::Menu.all.fake_structure_unique.where.not(ancestry: nil).select(:name).distinct
+
           result.each do |s|
-            if s.depth == 1
-              @parent_menu = Mokio::Menu.new(
-                name: s.name,
-                ancestry: @menu.id,
-                lang_id: self.id,
-                fake: true,
-                deletable:false,
-                editable:false
-              )
-              @parent_menu.save
-            end
+            @parent_menu = Mokio::Menu.new(
+              name: s.name,
+              ancestry: @menu.id,
+              lang_id: self.id,
+              fake: true,
+              deletable:false,
+              editable:false
+            )
+            @parent_menu.save
           end
         end
       end

--- a/lib/mokio/concerns/models/menu.rb
+++ b/lib/mokio/concerns/models/menu.rb
@@ -17,10 +17,10 @@ module Mokio
 
           validates :name, presence: true
           validates :lang_id, presence: true
-          validates_uniqueness_of :slug
+          validates_uniqueness_of :slug,case_sensitive: true
 
           belongs_to :lang
-          belongs_to :meta, :dependent => :destroy
+          belongs_to :meta, :dependent => :destroy,optional: true
 
           mount_uploader :main_pic, Mokio::MainPicUploader
 

--- a/lib/mokio/version.rb
+++ b/lib/mokio/version.rb
@@ -2,5 +2,5 @@ module Mokio
   #
   # Actual Mokio version
   #
-  VERSION = "2.0.3"
+  VERSION = "2.0.4"
 end


### PR DESCRIPTION
  1. 'Uniqueness validator will no longer enforce case sensitive comparison'
    Added: `case_sensitive: true` to :slug in
    - Mokio::Menu
    - Mokio::DataFile
  2. Updated: fake menu generation
  3. Fixed: Mokio::Menu belongs_to Mokio::Meta // optional: true
