### PR TITLE
Gallery load error in js - possible fix

### DIFF
--- a/app/views/mokio/photos/_gallery.html.slim
+++ b/app/views/mokio/photos/_gallery.html.slim
@@ -22,6 +22,6 @@ ul#itemContainer.galleryView.sortable
 
 - content_for :js do
   = render :partial => "mokio/photos/data_file_info"
-  = javascript_include_tag 'backend/photo_gallery/functions', :async => true
-  = javascript_include_tag 'backend/photo_gallery/photoEditForm', :async => true
-  = javascript_include_tag 'backend/photo_gallery/photo_gallery', :async => true
+  = javascript_include_tag 'backend/photo_gallery/functions'
+  = javascript_include_tag 'backend/photo_gallery/photoEditForm'
+  = javascript_include_tag 'backend/photo_gallery/photo_gallery'


### PR DESCRIPTION
Info:

Backend have error in js console after create pic gallery and auto redirect to edit action.

"gallery_load is not defined"

This is possible fix for this issue - im removed async true from js loading in photos/_galery.html.slim