### PR TITLE
Main pic fix for custom resources

### DIFF
--- a/app/views/mokio/common/_main_pic.html.slim
+++ b/app/views/mokio/common/_main_pic.html.slim
@@ -1,6 +1,8 @@
 = f.input :main_pic
-#main_pic_view
-  a.fancybox href=f.object.main_pic.url
-    img.image.marginR10.article-mainpic alt="" src=f.object.main_pic.url(:main_pic) /
-    - unless f.object.main_pic.file.nil?
-      = link_to "", delete_main_pic_content_path, method: :delete, remote: true, class: "delete-mainpic-button icon16 icomoon-icon-remove white"
+-if f.object.persisted?
+  #main_pic_view
+    a.fancybox href=f.object.main_pic.url
+      img.image.marginR10.article-mainpic alt="" src=f.object.main_pic.url(:main_pic) /
+      - unless f.object.main_pic.file.nil?
+        - url  = (f.object.class.base_class == Mokio::Content) ? delete_main_pic_content_path(f.object) : url_for([f.object, :delete_main_pic])
+        = link_to "", url, method: :delete, remote: true, class: "delete-mainpic-button icon16 icomoon-icon-remove white"

--- a/app/views/mokio/common/delete_main_pic.js.slim
+++ b/app/views/mokio/common/delete_main_pic.js.slim
@@ -1,0 +1,1 @@
+| $("[class$='-mainpic'], .delete-mainpic-button").css("display", "none");

--- a/app/views/mokio/contents/delete_main_pic.js.slim
+++ b/app/views/mokio/contents/delete_main_pic.js.slim
@@ -1,1 +1,0 @@
-| $(".article-mainpic, .delete-mainpic-button").css("display", "none");


### PR DESCRIPTION
Correction for the main picture and its delete address.
In the case of a resource that does not inherit from mokio::content, the view was generating an incorrect delete address for the picture.